### PR TITLE
Add SerializerUtil for faster map loading

### DIFF
--- a/src/main/java/io/personalityrecognition/util/SerializerUtil.java
+++ b/src/main/java/io/personalityrecognition/util/SerializerUtil.java
@@ -1,0 +1,44 @@
+package io.personalityrecognition.util;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author tom
+ */
+public class SerializerUtil {
+	public static void storeSerial(
+			HashMap<String,Map<String, Integer>> map, Path filePath)
+		throws IOException{
+
+		FileOutputStream fos = new FileOutputStream(filePath.toFile());
+
+        ObjectOutputStream oos = new ObjectOutputStream(fos);
+
+        oos.writeObject(map);
+        oos.flush();
+        oos.close();
+        fos.close();
+	}
+
+	public static HashMap<String,Map<String, Integer>> loadSerial(Path filePath)
+		throws Exception {
+
+		FileInputStream fis = new FileInputStream(filePath.toFile());
+        ObjectInputStream ois = new ObjectInputStream(fis);
+
+        HashMap<String,Map<String, Integer>> mapInFile =
+			(HashMap<String,Map<String, Integer>>)ois.readObject();
+
+        ois.close();
+        fis.close();
+
+		return mapInFile;
+	}
+}


### PR DESCRIPTION
Hey Ian this commit might be helpful for you so I will commit it ahead of others. 

I am not sure how you are storing the parsed data, but here is how I am using this util:

I load my bi grams and tri grams into a map organized by personality trait, so something like `map<String(trait), Map<String(bi-gram token), Integer(weight)>>.`

To organize all the articles into these maps (unigram, bigram, trigram, etc) takes around 30 seconds or so each. So I just use the serializer to output to a file and load it into the map when I need it. This would save time on multiple runs where we want to keep the trained ngrams the same. 

Not sure if you need this functionality but since i'll need it later on for my part i'll just commit this now.
